### PR TITLE
Linting config files

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,0 +1,23 @@
+module.exports = {
+  env: {
+    browser: true,
+    es6: true,
+    webextensions: true
+  },
+  extends: [
+    'eslint:recommended',
+    'plugin:mozilla/recommended'
+  ],
+  plugins: [
+    'json',
+    'mozilla'
+  ],
+  root: true,
+  rules: {
+    'eqeqeq': 'error',
+    'no-console': ['error', {allow: ['error', 'info', 'trace', 'warn']}],
+    'no-var': 'error',
+    'one-var': ['error', 'never'],
+    'prefer-const': 'error'
+  }
+};

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+web-ext-artifacts

--- a/.htmllintrc
+++ b/.htmllintrc
@@ -1,0 +1,7 @@
+{
+  "class-style": "underscore",
+  "head-req-title": null,
+  "id-class-style": "camel",
+  "indent-width": 2,
+  "indent-width-cont": true
+}

--- a/.stylelintrc
+++ b/.stylelintrc
@@ -1,0 +1,11 @@
+{
+  "extends": [
+    "stylelint-config-recommended",
+    "stylelint-config-standard"
+  ],
+  "rules": {
+    "rule-empty-line-before": null,
+    "selector-combinator-space-before": null,
+    "selector-combinator-space-after": null
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "webcompat-blipz-experiment",
+  "version": "1.0.0",
+  "author": "Mozilla",
+  "bugs": {
+    "url": "https://github.com/mozilla/webcompat-blipz-experiment/issues"
+  },
+  "devDependencies": {
+    "eslint": "4.19.1",
+    "eslint-plugin-json": "1.2.0",
+    "eslint-plugin-mozilla": "0.11.0",
+    "eslint-plugin-no-unsanitized": "3.0.0",
+    "htmllint-cli": "0.0.7",
+    "npm-run-all": "4.1.2",
+    "stylelint": "9.2.0",
+    "stylelint-config-recommended": "2.1.0",
+    "stylelint-config-standard": "18.2.0",
+    "web-ext": "2.6.0"
+  },
+  "homepage": "https://github.com/mozilla/webcompat-blipz-experiment#readme",
+  "keywords": [],
+  "license": "MPL-2.0",
+  "private": true,
+  "repository": "mozilla/webcompat-blipz-experiment",
+  "scripts": {
+    "build": "web-ext build",
+    "firefox": "web-ext run",
+    "lint": "npm-run-all lint:*",
+    "lint:addon": "web-ext lint",
+    "lint:css": "stylelint webextension/**/*.css",
+    "lint:html": "htmllint webextension/*.html",
+    "lint:js": "DEBUG=eslint:cli-engine eslint webextension --ext=js,jsm,json",
+    "pretest": "npm run lint",
+    "test": "echo \"Error: no test specified\" && exit 0"
+  }
+}

--- a/web-ext-config.js
+++ b/web-ext-config.js
@@ -1,0 +1,10 @@
+module.exports = {
+  sourceDir: 'webextension',
+  verbose: true,
+  build: {
+    overwriteDest: true
+  },
+  run: {
+    firefox: 'nightly'
+  }
+};


### PR DESCRIPTION
For my own future reference, here's a PR with a package.json, and all my linting configs in a single place (instead of spread out over 4 PRs).

You should just be able to do an <kbd>$ npm install</kbd> and then run <kbd>$ npm run lint</kbd> to lint all the CSS/JS/JSON/HTML/WebExt in a single command, or run each `lint:___` command separately.

There are also two other **web-ext** convenience scripts in package.json:

1. <kbd>$ npm run build</kbd> &mdash; creates a ZIP from the ./webextension/* files in the ./web-ext-artifacts/ folder.
2. <kbd>$ npm run firefox</kbd> &mdash; launches a Firefox [Nightly] browser with the add-on preinstalled.

This PR would also be useful if you decide to hook up Travis-CI or Circle-CI to do linting on a per-PR basis.
