### PR TITLE
Implement state saving/loading for addon (to about:config and webext storage) #40

### DIFF
--- a/webextension/aboutConfigPrefs.js
+++ b/webextension/aboutConfigPrefs.js
@@ -1,0 +1,63 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+"use strict";
+
+/* global ExtensionAPI, Services */
+
+ChromeUtils.import("resource://gre/modules/Services.jsm");
+ChromeUtils.import("resource://gre/modules/ExtensionCommon.jsm");
+
+const EventManager = ExtensionCommon.EventManager;
+
+this.aboutConfigPrefs = class extends ExtensionAPI {
+  getAPI(context) {
+    const extensionIDBase = context.extension.id.split("@")[0];
+    const prefBranchPrefix = `extensions.${extensionIDBase}.`;
+    const prefBranch = Services.prefs.getBranch(prefBranchPrefix);
+    const prefChangeEventName = "experiments.aboutConfigPrefs.onPrefChange";
+
+    function get(type, name) {
+      try {
+        return prefBranch[`get${type}Pref`](name);
+      } catch (_) {
+        return undefined;
+      }
+    }
+
+    return {
+      experiments: {
+        aboutConfigPrefs: {
+          onPrefChange: new EventManager(context, prefChangeEventName, (fire, name) => {
+            const callback = () => {
+              fire.async();
+            };
+            Services.prefs.addObserver(`${prefBranchPrefix}${name}`, callback);
+            return () => {
+              Services.prefs.removeObserver(name, callback);
+            };
+          }).api(),
+          async getBool(name) {
+            return get("Bool", name);
+          },
+          async setBool(name, value) {
+            prefBranch.setBoolPref(name, value);
+          },
+          async getInt(name) {
+            return get("Int", name);
+          },
+          async setInt(name, value) {
+            prefBranch.setIntPref(name, value);
+          },
+          async getString(name) {
+            return get("String", name);
+          },
+          async setString(name, value) {
+            prefBranch.setStringPref(name, value);
+          },
+        },
+      },
+    };
+  }
+};

--- a/webextension/aboutConfigPrefs.js
+++ b/webextension/aboutConfigPrefs.js
@@ -38,7 +38,7 @@ this.aboutConfigPrefs = class extends ExtensionAPI {
             };
             Services.prefs.addObserver(`${prefBranchPrefix}${name}`, callback);
             return () => {
-              Services.prefs.removeObserver(name, callback);
+              Services.prefs.removeObserver(`${prefBranchPrefix}${name}`, callback);
             };
           }).api(),
           async clearPref(name) {

--- a/webextension/aboutConfigPrefs.json
+++ b/webextension/aboutConfigPrefs.json
@@ -1,0 +1,114 @@
+[
+  {
+    "namespace": "experiments.aboutConfigPrefs",
+    "description": "experimental API extension to allow access to about:config preferences",
+    "events": [
+      {
+        "name": "onPrefChange",
+        "type": "function",
+        "extraParameters": [
+          {
+            "name": "name",
+            "type": "string",
+            "description": "The preference to monitor"
+          }
+        ]
+      }
+    ],
+    "functions": [
+      {
+        "name": "getBool",
+        "type": "function",
+        "description": "Get a boolean preference from the extension's preference branch",
+        "parameters": [
+          {
+            "name": "name",
+            "type": "string",
+            "description": "The preference name"
+          }
+        ],
+        "async": true
+      },
+      {
+        "name": "setBool",
+        "type": "function",
+        "description": "Set a boolean preference in the extension's preference branch",
+        "parameters": [
+          {
+            "name": "name",
+            "type": "string",
+            "description": "The preference name"
+          },
+          {
+            "name": "value",
+            "type": "boolean",
+            "description": "The new value"
+          }
+        ],
+        "async": true
+      },
+      {
+        "name": "getInt",
+        "type": "function",
+        "description": "Get an integer preference from the extension's preference branch",
+        "parameters": [
+          {
+            "name": "name",
+            "type": "string",
+            "description": "The preference name"
+          }
+        ],
+        "async": true
+      },
+      {
+        "name": "setInt",
+        "type": "function",
+        "description": "Set an integer preference in the extension's preference branch",
+        "parameters": [
+          {
+            "name": "name",
+            "type": "string",
+            "description": "The preference name"
+          },
+          {
+            "name": "value",
+            "type": "integer",
+            "description": "The new value"
+          }
+        ],
+        "async": true
+      },
+      {
+        "name": "getString",
+        "type": "function",
+        "description": "Get a string preference from the extension's preference branch",
+        "parameters": [
+          {
+            "name": "name",
+            "type": "string",
+            "description": "The preference name"
+          }
+        ],
+        "async": true
+      },
+      {
+        "name": "setString",
+        "type": "function",
+        "description": "Set a string preference in the extension's preference branch",
+        "parameters": [
+          {
+            "name": "name",
+            "type": "string",
+            "description": "The preference name"
+          },
+          {
+            "name": "value",
+            "type": "string",
+            "description": "The new value"
+          }
+        ],
+        "async": true
+      }
+    ]
+  }
+]

--- a/webextension/aboutConfigPrefs.json
+++ b/webextension/aboutConfigPrefs.json
@@ -17,6 +17,35 @@
     ],
     "functions": [
       {
+        "name": "clearPref",
+        "type": "function",
+        "description": "Clear a preference from the extension's preference branch",
+        "parameters": [
+          {
+            "name": "name",
+            "type": "string",
+            "description": "The preference name"
+          }
+        ],
+        "async": true
+      },
+      {
+        "name": "clearPrefsOnUninstall",
+        "type": "function",
+        "description": "Automatically clears preferences from the extension's preference branch when the addon is uninstalled",
+        "parameters": [
+          {
+            "name": "names",
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "The preference names"
+          }
+        ],
+        "async": true
+      },
+      {
         "name": "getBool",
         "type": "function",
         "description": "Get a boolean preference from the extension's preference branch",

--- a/webextension/background.js
+++ b/webextension/background.js
@@ -9,6 +9,8 @@
 let gCurrentlyPromptingTab;
 
 const Config = (function() {
+  browser.experiments.aboutConfigPrefs.clearPrefsOnUninstall(["enabled"]);
+
   class Config {
     constructor() {
       this._neverShowAgain = false;

--- a/webextension/browserInfo.js
+++ b/webextension/browserInfo.js
@@ -1,0 +1,27 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+"use strict";
+
+/* global AppConstants, ExtensionAPI, Services */
+
+ChromeUtils.import("resource://gre/modules/AppConstants.jsm");
+ChromeUtils.import("resource://gre/modules/Services.jsm");
+
+this.browserInfo = class extends ExtensionAPI {
+  getAPI(context) {
+    return {
+      experiments: {
+        browserInfo: {
+          async getBuildID() {
+            return Services.appinfo.appBuildID;
+          },
+          async getUpdateChannel() {
+            return AppConstants.MOZ_UPDATE_CHANNEL;
+          },
+        },
+      },
+    };
+  }
+};

--- a/webextension/browserInfo.json
+++ b/webextension/browserInfo.json
@@ -1,0 +1,22 @@
+[
+  {
+    "namespace": "experiments.browserInfo",
+    "description": "experimental API extensions to get browser info not exposed via web APIs",
+    "functions": [
+      {
+        "name": "getBuildID",
+        "type": "function",
+        "description": "Gets the build ID",
+        "parameters": [],
+        "async": true
+      },
+      {
+        "name": "getUpdateChannel",
+        "type": "function",
+        "description": "Gets the update channel",
+        "parameters": [],
+        "async": true
+      }
+    ]
+  }
+]

--- a/webextension/manifest.json
+++ b/webextension/manifest.json
@@ -12,6 +12,22 @@
     }
   },
   "experiment_apis": {
+    "aboutConfigPrefs": {
+      "schema": "aboutConfigPrefs.json",
+      "parent": {
+        "scopes": ["addon_parent"],
+        "script": "aboutConfigPrefs.js",
+        "paths": [["experiments", "aboutConfigPrefs"]]
+      }
+    },
+    "browserInfo": {
+      "schema": "browserInfo.json",
+      "parent": {
+        "scopes": ["addon_parent"],
+        "script": "browserInfo.js",
+        "paths": [["experiments", "browserInfo"]]
+      }
+    },
     "forceOpenPageActionPopup": {
       "schema": "forceOpenPageActionPopup.json",
       "parent": {
@@ -29,6 +45,7 @@
     "128": "icons/broken_page.svg"
   },
   "permissions": [
+    "storage",
     "tabs",
     "webNavigation",
     "<all_urls>"


### PR DESCRIPTION
For the addon's persisted state, I split on just storing the addon's global enable/disable toggle in `about:config`, with the rest of the less interesting info going into the addon's local webextension data store via `browser.storage.local`. This is done in the interests of minimizing our use of `about:config`.

The enable/disable toggle is `extensions.webcompat-blipz-experiment.enabled`, and it's removed outright when the addon is uninstalled.

With this setup, to alter the list of domains we're interested in we will just push a new version of the addon with the revisions right in the JS code, and upon upgrade each user's instance of the addon will detect the new list and sync which ones for which the user has been prompted already.

This PR also adds a couple of extension experiments; obviously one for `about:config` access, but also one for getting AppConstants (I figured I might as well do both since they involved similar work).