### PR TITLE
Implement UI variations for 3 study branches #54

### DIFF
--- a/webextension/_locales/en_US/messages.json
+++ b/webextension/_locales/en_US/messages.json
@@ -71,6 +71,12 @@
     "message": "Description"
   },
 
+  "titleInitialPromptNoContext": {
+    "message": "Are you satisfied with how this website works in Firefox?"
+  },
+  "textInitialPromptNoContext": {
+    "message": "Help us make the web better for everyone."
+  },
   "titleInitialPrompt": {
     "message": "Firefox wants to know: are you satisfied with the way this website is working?"
   },

--- a/webextension/_locales/en_US/messages.json
+++ b/webextension/_locales/en_US/messages.json
@@ -71,16 +71,16 @@
     "message": "Description"
   },
 
-  "titleInitialPromptNoContext": {
+  "titleInitialPromptBasic": {
     "message": "Are you satisfied with how this website works in Firefox?"
   },
-  "textInitialPromptNoContext": {
+  "textInitialPromptBasic": {
     "message": "Help us make the web better for everyone."
   },
-  "titleInitialPrompt": {
+  "titleInitialPromptFriendly": {
     "message": "Firefox wants to know: are you satisfied with the way this website is working?"
   },
-  "textInitialPrompt": {
+  "textInitialPromptFriendly": {
     "message": "Help us to better detect issues with the web."
   },
   "linkInitialPrompt": {

--- a/webextension/aboutConfigPrefs.js
+++ b/webextension/aboutConfigPrefs.js
@@ -34,7 +34,7 @@ this.aboutConfigPrefs = class extends ExtensionAPI {
         aboutConfigPrefs: {
           onPrefChange: new EventManager(context, prefChangeEventName, (fire, name) => {
             const callback = () => {
-              fire.async();
+              fire.async(name);
             };
             Services.prefs.addObserver(`${prefBranchPrefix}${name}`, callback);
             return () => {

--- a/webextension/aboutConfigPrefs.json
+++ b/webextension/aboutConfigPrefs.json
@@ -6,6 +6,11 @@
       {
         "name": "onPrefChange",
         "type": "function",
+        "parameters": [{
+          "name": "name",
+          "type": "string",
+          "description": "The preference which changed"
+        }],
         "extraParameters": [
           {
             "name": "name",

--- a/webextension/background.js
+++ b/webextension/background.js
@@ -9,10 +9,13 @@
 let gCurrentlyPromptingTab;
 
 const Config = (function() {
-  browser.experiments.aboutConfigPrefs.clearPrefsOnUninstall(["enabled"]);
+  browser.experiments.aboutConfigPrefs.clearPrefsOnUninstall(["enabled", "branch"]);
+
+  const UIVariants = ["more-context", "little-context", "no-context"];
 
   class Config {
     constructor() {
+      this._testingMode = true;
       this._neverShowAgain = false;
       this._skipPrivateBrowsingTabs = true;
       this._lastPromptTime = 0;
@@ -46,19 +49,60 @@ const Config = (function() {
 
       browser.experiments.aboutConfigPrefs.onPrefChange.addListener(
         this._onAboutConfigPrefChanged.bind(this), "enabled");
+
+      browser.experiments.aboutConfigPrefs.onPrefChange.addListener(
+        this._onAboutConfigPrefChanged.bind(this), "branch");
     }
 
-    _onAboutConfigPrefChanged() {
-      browser.experiments.aboutConfigPrefs.getBool("enabled").then(value => {
-        if (value !== undefined) {
-          this._neverShowAgain = !value;
-          if (value) {
-            activate();
-          } else {
-            deactivate();
-          }
+    _onAboutConfigPrefChanged(name) {
+      if (name === "enabled") {
+        browser.experiments.aboutConfigPrefs.getBool("enabled").then(value => {
+          this._onEnabledPrefChanged(value);
+        });
+      } else if (name === "branch") {
+        browser.experiments.aboutConfigPrefs.getString("branch").then(value => {
+          this._onBranchPrefChanged(value);
+        });
+      }
+    }
+
+    _onEnabledPrefChanged() {
+      if (value !== undefined) {
+        this._neverShowAgain = !value;
+        if (value) {
+          activate();
+        } else {
+          deactivate();
         }
-      });
+      }
+    }
+
+    _onBranchPrefChanged(branchPref) {
+      if (UIVariants.includes(branchPref)) {
+        this.uiVariant = branchPref;
+        return true;
+      } else {
+        // If an invalid value was used, just reset the addon's
+        // state and pick a new UI variant (useful for testing).
+        this._selectRandomUIVariant();
+        this._lastPromptTime = 0;
+        for (const key of Object.keys(this._domainsToCheck)) {
+          this._domainsToCheck[key] = 0;
+        }
+        this.save({
+          lastPromptTime: this._lastPromptTime,
+          domainsToCheck: this._domainsToCheck,
+        });
+        return false;
+      }
+    }
+
+    _selectRandomUIVariant() {
+      this.uiVariant = UIVariants[Math.floor(Math.random() * UIVariants.length)];
+
+      if (this._testingMode) {
+        browser.experiments.aboutConfigPrefs.setString("branch", this._uiVariant);
+      }
     }
 
     load() {
@@ -67,8 +111,10 @@ const Config = (function() {
         browser.experiments.browserInfo.getPlatform(),
         browser.experiments.browserInfo.getUpdateChannel(),
         browser.experiments.aboutConfigPrefs.getBool("enabled"),
+        browser.experiments.aboutConfigPrefs.getString("branch"),
         browser.storage.local.get(),
-      ]).then(([buildID, platform, releaseChannel, enabledPref, otherPrefs]) => {
+      ]).then(([buildID, platform, releaseChannel,
+                enabledPref, branchPref, otherPrefs]) => {
         this._buildID = buildID;
         this._platform = platform;
         this._releaseChannel = releaseChannel;
@@ -79,6 +125,16 @@ const Config = (function() {
         // from them being in about:config anyway.
         if (enabledPref !== undefined) {
           this._neverShowAgain = !enabledPref;
+        }
+
+        // Testers may use an about:config flag to toggle the UI variant.
+        // They may also use an invalid value to reset our config.
+        if (this._testingMode && branchPref !== undefined) {
+          if (this._onBranchPrefChanged(branchPref)) {
+            delete otherPrefs.uiVariant;
+          } else {
+            otherPrefs = {};
+          }
         }
 
         // The list of domains to check needs special handling, as the list may
@@ -104,6 +160,11 @@ const Config = (function() {
         // we will have written them out with a valid value to begin with.
         for (const [name, value] of Object.entries(otherPrefs)) {
           this[`_${name}`] = value;
+        }
+
+        // If a valid UI variant has not otherwise been chosen yet, select one now.
+        if (!this._uiVariant) {
+          this._selectRandomUIVariant();
         }
       });
     }
@@ -193,6 +254,15 @@ const Config = (function() {
     set skipPrivateBrowsingTabs(bool) {
       this._skipPrivateBrowsingTabs = bool;
       this.save({skipPrivateBrowsingTabs: bool});
+    }
+
+    get uiVariant() {
+      return this._uiVariant;
+    }
+
+    set uiVariant(uiVariant) {
+      this._uiVariant = uiVariant;
+      this.save({uiVariant});
     }
 
     get releaseChannel() {
@@ -288,6 +358,7 @@ const TabState = (function() {
         const info = Object.assign({}, this._report, {
           tabId: this._tabId,
           slide: this._slide,
+          uiVariant: Config.uiVariant,
         });
         let update;
         if (!onlyProperties) {
@@ -367,6 +438,7 @@ const TabState = (function() {
         if (incognito !== undefined) {
           report.incognito = incognito;
         }
+        report.branch = Config.uiVariant;
         report.buildID = Config.buildID;
         report.platform = Config.platform;
         report.releaseChannel = Config.releaseChannel;

--- a/webextension/popup.css
+++ b/webextension/popup.css
@@ -165,6 +165,14 @@ section > h1 + button:only-of-type {
 #thankYou > h1 {
   margin-top: 1.75em;
 }
+.no-context #initialPrompt a,
+.no-context #thankYou p,
+.no-context #thankYouFeedback p,
+.no-context #thankYouFeedback a,
+.little-context #thankYouFeedback p,
+.little-context #thankYouFeedback a {
+  display: none;
+}
 #thankYouFeedback > a {
   float: right;
   margin-top: 1.5em;
@@ -228,6 +236,8 @@ button[data-action="back"] {
 #initialPrompt > h1::before { content: "__MSG_titleInitialPrompt__"; }
 #initialPrompt > p::before { content: "__MSG_textInitialPrompt__"; }
 #initialPrompt > a::before { content: "__MSG_linkInitialPrompt__"; }
+.no-context #initialPrompt > h1::before { content: "__MSG_titleInitialPromptNoContext__"; }
+.no-context #initialPrompt > p::before { content: "__MSG_textInitialPromptNoContext__"; }
 
 #initialPrompt > label::after { content: "__MSG_labelNeverShowAgain__"; }
 

--- a/webextension/popup.css
+++ b/webextension/popup.css
@@ -165,14 +165,6 @@ section > h1 + button:only-of-type {
 #thankYou > h1 {
   margin-top: 1.75em;
 }
-.no-context #initialPrompt a,
-.no-context #thankYou p,
-.no-context #thankYouFeedback p,
-.no-context #thankYouFeedback a,
-.little-context #thankYouFeedback p,
-.little-context #thankYouFeedback a {
-  display: none;
-}
 #thankYouFeedback > a {
   float: right;
   margin-top: 1.5em;
@@ -233,11 +225,18 @@ button[data-action="back"] {
   background-size: 12px 12px;
 }
 
-#initialPrompt > h1::before { content: "__MSG_titleInitialPrompt__"; }
-#initialPrompt > p::before { content: "__MSG_textInitialPrompt__"; }
+.no-context #initialPrompt a,
+.no-context #thankYou p,
+.no-context #thankYouFeedback p,
+.no-context #thankYouFeedback a,
+.little-context #thankYouFeedback p,
+.little-context #thankYouFeedback a {
+  display: none;
+}
+
+#initialPrompt > h1::before { content: "__MSG_titleInitialPromptFriendly__"; }
+#initialPrompt > p::before { content: "__MSG_textInitialPromptFriendly__"; }
 #initialPrompt > a::before { content: "__MSG_linkInitialPrompt__"; }
-.no-context #initialPrompt > h1::before { content: "__MSG_titleInitialPromptNoContext__"; }
-.no-context #initialPrompt > p::before { content: "__MSG_textInitialPromptNoContext__"; }
 
 #initialPrompt > label::after { content: "__MSG_labelNeverShowAgain__"; }
 
@@ -251,6 +250,9 @@ button[data-action="back"] {
 #feedbackForm > p::after { content: "__MSG_textFeedbackForm__"; }
 #feedbackForm > label::after { content: "__MSG_labelIncludeURL__"; }
 #issueRemoveScreenshot > p::after { content: "__MSG_textScreenshotOfIssue__"; }
+
+.no-context #initialPrompt > h1::before { content: "__MSG_titleInitialPromptBasic_"; }
+.no-context #initialPrompt > p::before { content: "__MSG_textInitialPromptBasic__"; }
 
 button[data-action="ok"]::before { content: "__MSG_buttonOK__"; }
 button[data-action="yes"]::before { content: "__MSG_buttonYes__"; }

--- a/webextension/popup.js
+++ b/webextension/popup.js
@@ -89,6 +89,13 @@ function onMessage(update) {
     return;
   }
 
+  if (update.uiVariant && gState.uiVariant !== update.uiVariant) {
+    if (gState.uiVariant) {
+      document.documentElement.classList.remove(gState.uiVariant);
+    }
+    document.documentElement.classList.add(update.uiVariant);
+  }
+
   Object.assign(gState, update);
 
   if (update.slide) {


### PR DESCRIPTION
This implements the three UI variants, and picks one at random for now without the Shield studies extension APIs being involved yet.

It also adds the ability to set the `about:config` value `extensions.webcompat-blipz-experiments.branch` to one of the values to dynamically change between variants on-the-fly (and if an unexpected value is used, the addon picks a new one at random, and resets the addon so it thinks you've never been prompted for any domains, just like reinstalling it.