### PR TITLE
Add a feedback details slide to show what we will send. #44

### DIFF
--- a/.htmllintrc
+++ b/.htmllintrc
@@ -1,5 +1,4 @@
 {
-  "class-style": "underscore",
   "head-req-title": null,
   "id-class-style": "camel",
   "indent-width": 2,

--- a/webextension/_locales/en_US/messages.json
+++ b/webextension/_locales/en_US/messages.json
@@ -31,6 +31,31 @@
     "message": "Yes"
   },
 
+  "detailLabel_appVersion": {
+    "message": "Version:"
+  },
+  "detailLabel_buildID": {
+    "message": "Build ID:"
+  },
+  "detailLabel_channel": {
+    "message": "Channel:"
+  },
+  "detailLabel_description": {
+    "message": "Description:"
+  },
+  "detailLabel_experimentBranch": {
+    "message": "Experiment Branch:"
+  },
+  "detailLabel_platform": {
+    "message": "Platform:"
+  },
+  "detailLabel_type": {
+    "message": "Type:"
+  },
+  "detailLabel_url": {
+    "message": "URL:"
+  },
+
   "errorScreenshotFail": {
     "message": "Error taking a screenshot"
   },
@@ -54,9 +79,6 @@
     "message": "Something else"
   },
 
-  "labelIncludeURL": {
-    "message": "Include the address of this website with your feedback"
-  },
   "labelLearnMore": {
     "message": "Learn More"
   },
@@ -103,6 +125,16 @@
   },
   "textFeedbackForm": {
     "message": "Please tell us more about your experience on this site so we can understand and fix the issue."
+  },
+
+  "titleFeedbackDetails": {
+    "message": "Feedback details"
+  },
+  "textFeedbackDetails": {
+    "message": "This data is non-public. Only certain Mozilla employees will have access to this data."
+  },
+  "linkShowFeedbackDetails": {
+    "message": "See what data I am sending"
   },
 
   "textScreenshotOfIssue": {

--- a/webextension/browserInfo.js
+++ b/webextension/browserInfo.js
@@ -14,6 +14,9 @@ this.browserInfo = class extends ExtensionAPI {
     return {
       experiments: {
         browserInfo: {
+          async getAppVersion() {
+            return AppConstants.MOZ_APP_VERSION;
+          },
           async getBuildID() {
             return Services.appinfo.appBuildID;
           },

--- a/webextension/browserInfo.json
+++ b/webextension/browserInfo.json
@@ -4,6 +4,13 @@
     "description": "experimental API extensions to get browser info not exposed via web APIs",
     "functions": [
       {
+        "name": "getAppVersion",
+        "type": "function",
+        "description": "Gets the app version",
+        "parameters": [],
+        "async": true
+      },
+      {
         "name": "getBuildID",
         "type": "function",
         "description": "Gets the build ID",

--- a/webextension/popup.css
+++ b/webextension/popup.css
@@ -71,8 +71,10 @@ section > h2 {
 section > a,
 section > p,
 section > h1,
+section > div,
 section > form,
-section > label {
+section > label,
+section > table {
   margin-left: 75px;
   margin-right: 45px;
 }
@@ -108,9 +110,21 @@ section > label {
 }
 section > p,
 section > button,
-section > label {
+section > label,
+section > table {
   font-size: 1rem;
   line-height: 1.25em;
+}
+section > table tr {
+  display: block;
+}
+section > table th {
+  font-weight: bold;
+  padding-right: 0.5em;
+}
+section > table th,
+section > table td {
+  display: inline;
 }
 section > form > * {
   display: block;
@@ -155,13 +169,6 @@ button:focus {
   color: #fff;
   background-color: #0260de;
 }
-section > button:only-of-type {
-  margin-top: 0.75em;
-  width: 100%;
-}
-section > h1 + button:only-of-type {
-  margin-top: 2.5em;
-}
 #thankYou > h1 {
   margin-top: 1.75em;
 }
@@ -178,18 +185,18 @@ section > h1 + button:only-of-type {
   margin-bottom: 0;
 }
 
-#issueTakeScreenshot,
-#issueRemoveScreenshot {
+.takeScreenshot,
+.screenshot {
   display: block;
 }
-#issueRemoveScreenshot {
+.screenshot {
   padding-right: 16px;
 }
-#issueRemoveScreenshot > * {
+.screenshot > * {
   vertical-align: top;
   display: inline-block;
 }
-#issueRemoveScreenshot > img {
+.screenshot > img {
   cursor: pointer;
   display: none;
   margin-left: 0.5em;
@@ -198,7 +205,7 @@ section > h1 + button:only-of-type {
   border: 1px solid #eee;
   border-radius: 4px;
 }
-#issueRemoveScreenshot > button {
+.screenshot > button {
   padding: 0;
   width: 30px;
   height: 30px;
@@ -213,6 +220,13 @@ section > h1 + button:only-of-type {
   border-radius: 15px;
   box-shadow: 0 2px 2px rgba(128, 128, 128, 0.2);
 }
+section > button:only-of-type {
+  margin-top: 0.75em;
+  width: 100%;
+}
+section > h1 + button:only-of-type {
+  margin-top: 2.5em;
+}
 #thankYou,
 #thankYouFeedback {
   background-image: url(icons/done.svg);
@@ -223,6 +237,14 @@ section > h1 + button:only-of-type {
 button[data-action="back"] {
   background-image: url(icons/back.svg);
   background-size: 12px 12px;
+}
+
+#feedbackDetails .screenshot {
+  margin-top: 1em;
+}
+#feedbackDetails p {
+  margin-top: 1em;
+  margin-bottom: 1em;
 }
 
 .no-context #initialPrompt a,
@@ -246,13 +268,26 @@ button[data-action="back"] {
 #thankYouFeedback > p::before { content: "__MSG_textThankYouFeedback__"; }
 #thankYouFeedback > a::after { content: "__MSG_labelLearnMore__"; }
 
+.screenshot > p::after { content: "__MSG_textScreenshotOfIssue__"; }
+
 #feedbackForm > h2::before { content: "__MSG_titleFeedbackForm__"; }
 #feedbackForm > p::after { content: "__MSG_textFeedbackForm__"; }
-#feedbackForm > label::after { content: "__MSG_labelIncludeURL__"; }
-#issueRemoveScreenshot > p::after { content: "__MSG_textScreenshotOfIssue__"; }
+#feedbackForm > a::after { content: "__MSG_linkShowFeedbackDetails__"; }
+
+#feedbackDetails > h2::before { content: "__MSG_titleFeedbackDetails__"; }
+#feedbackDetails > p::before { content: "__MSG_textFeedbackDetails__"; }
 
 .no-context #initialPrompt > h1::before { content: "__MSG_titleInitialPromptBasic__"; }
 .no-context #initialPrompt > p::before { content: "__MSG_textInitialPromptBasic__"; }
+
+[data-detail="url"] > th::before { content: "__MSG_detailLabel_url__"; }
+[data-detail="type"] > th::before { content: "__MSG_detailLabel_type__"; }
+[data-detail="description"] > th::before { content: "__MSG_detailLabel_description__"; }
+[data-detail="channel"] > th::before { content: "__MSG_detailLabel_channel__"; }
+[data-detail="appVersion"] > th::before { content: "__MSG_detailLabel_appVersion__"; }
+[data-detail="platform"] > th::before { content: "__MSG_detailLabel_platform__"; }
+[data-detail="buildID"] > th::before { content: "__MSG_detailLabel_buildID__"; }
+[data-detail="uiVariant"] > th::before { content: "__MSG_detailLabel_experimentBranch__"; }
 
 button[data-action="ok"]::before { content: "__MSG_buttonOK__"; }
 button[data-action="yes"]::before { content: "__MSG_buttonYes__"; }
@@ -260,7 +295,7 @@ button[data-action="no"]::before { content: "__MSG_buttonNo__"; }
 button[data-action="submit"]::before { content: "__MSG_buttonSubmit__"; }
 button[data-action="cancel"]::before { content: "__MSG_buttonCancel__"; }
 
-#issueTakeScreenshot::before {
+.takeScreenshot::before {
   content: "__MSG_buttonTakeScreenshot__";
   background: url(icons/screenshot.svg) no-repeat;
   padding-left: 24px;

--- a/webextension/popup.html
+++ b/webextension/popup.html
@@ -52,7 +52,7 @@
         </div>
         <textarea name="description" rows="1"></textarea>
       </form>
-      <a href="#" data-action="showFeedbackDetails"></a>
+      <a href="#" role="button" data-action="showFeedbackDetails"></a>
       <button data-action="cancel"></button>
       <button data-action="submit" class="emphasize"></button>
     </section>

--- a/webextension/popup.html
+++ b/webextension/popup.html
@@ -36,7 +36,7 @@
       </h2>
       <p></p>
       <form>
-        <select name="issueType" required>
+        <select name="type" required>
           <option value="" hidden></option>
           <option value="desktopNotMobile"></option>
           <option value="siteUnusable"></option>
@@ -44,17 +44,37 @@
           <option value="playbackFailure"></option>
           <option value="other"></option>
         </select>
-        <button id="issueTakeScreenshot"></button>
-        <div id="issueRemoveScreenshot">
+        <button class="takeScreenshot"></button>
+        <div class="screenshot">
           <p></p>
           <img src="screenshot.jpg" alt="" />
           <button></button>
         </div>
-        <textarea name="issueDescription" rows="1"></textarea>
+        <textarea name="description" rows="1"></textarea>
       </form>
-      <label>
-        <input type="checkbox" name="includeURL" checked />
-      </label>
+      <a href="#" data-action="showFeedbackDetails"></a>
+      <button data-action="cancel"></button>
+      <button data-action="submit" class="emphasize"></button>
+    </section>
+    <section id="feedbackDetails">
+      <h2>
+        <button data-action="back"></button>
+      </h2>
+      <table>
+        <tr data-detail="url"><th></th><td></td></tr>
+        <tr data-detail="type"><th></th><td></td></tr>
+        <tr data-detail="description"><th></th><td></td></tr>
+        <tr data-detail="channel"><th></th><td></td></tr>
+        <tr data-detail="appVersion"><th></th><td></td></tr>
+        <tr data-detail="platform"><th></th><td></td></tr>
+        <tr data-detail="buildID"><th></th><td></td></tr>
+        <tr data-detail="uiVariant"><th></th><td></td></tr>
+      </table>
+      <div class="screenshot">
+        <p></p>
+        <img src="screenshot.jpg" alt="" />
+      </div>
+      <p></p>
       <button data-action="cancel"></button>
       <button data-action="submit" class="emphasize"></button>
     </section>


### PR DESCRIPTION
This PR basically just adds the new slide, but also does some other relatively minor stuff;
- I made the screenshot UI code more reusable
- I cleaned up how the tab and report state are managed a little
- I cleaned up some of the message-passing stuff between the popup and background script ("command" and "action" were really the same thing, "option" isn't used anymore, "includeURL" is gone now, and "issueType/Description" are now passed as just "type/description").
- I removed the unnecessary distinction between "command" and "action" messages from the popup script (including removing a reference to a no-longer-used "option" message parameter).
- I added the API experiment and code needed to get/set the appVersion on the report.

I think the only potentially contentious change is that I changed the CSS linting to allow camel-case classes (rather than just underscored ones). But if this is to match a style guide, or anyone here prefers the underscore restriction strongly enough, I can work around it.