### PR TITLE
Implement calls to Shield telemetry #2

### DIFF
--- a/webextension/background.js
+++ b/webextension/background.js
@@ -454,13 +454,6 @@ const portToPageAction = (function() {
       // When the page action popup is hidden.
       port = undefined;
 
-      // Inform whichever tab we were actually prompting on/for.
-      if (gCurrentlyPromptingTab) {
-        TabState.get(gCurrentlyPromptingTab.id).then(tabState => {
-          tabState.onPageActionHidden();
-        });
-      }
-
       // Update the page action icon for whichever tab we're on now,
       // or deactivate ourselves if the user clicked "never show again".
       TabState.get().then(tabState => {
@@ -637,16 +630,6 @@ const TabState = (function() {
       gCurrentlyPromptingTab = {id: this._tabId, url: this._url};
       updatePageActionIcon(this._tabId);
       this.maybeUpdatePageAction();
-    }
-
-    onPageActionHidden() {
-      // If the page action closes and it is not because the user has
-      // just clicked an internal link/screenshot (both of which will
-      // open a tab and close the page action), then we presume the
-      // user dismissed the popup themselves.
-      if (!this.takenPageActionExit) {
-        this.maybeSendTelemetry({userDismissed: "yes"});
-      }
     }
 
     _backgroundSendReport(data) {

--- a/webextension/background.js
+++ b/webextension/background.js
@@ -127,10 +127,6 @@ const Config = (function() {
       }
     }
 
-    maybeSendTelemetry(message) {
-      browser.study.sendTelemetry(message);
-    }
-
     get shieldStudySetup() {
       const pref = `extensions.${browser.runtime.id.split("@")[0]}.variation`;
       return {
@@ -447,81 +443,37 @@ function yesOrNo(bool) {
   return bool ? "yes" : "no";
 }
 
-function backgroundSendReport(data) {
-  data.type = browser.i18n.getMessage(`issueLabel${data.type}`);
-
-  const body = ["url", "type", "appVersion", "channel", "platform", "buildID",
-                "experimentBranch", "description"].map(function(name) {
-      const label = browser.i18n.getMessage(`detailLabel_${name}`);
-      const value = data[name] || "";
-      return `**${label}** ${value}`;
-    }).join("\n");
-
-  const domain = Config.findDomainMatch(new URL(data.url).host);
-
-  const report = {
-    title: `${domain} - ${data.type}`,
-    body,
-    labels: [`variant-${data.experimentBranch}`],
-  };
-
-  if (data.userPrompted) {
-    report.labels.push("user-prompted");
-  }
-
-  if (data.screenshot) {
-    report.screenshot = data.screenshot;
-  }
-
-  if (Config.testingMode) {
-    console.info("Would submit this report: ", report);
-    return Promise.resolve();
-  }
-
-  const fd = new FormData();
-  for (const [key, value] of Object.entries(report)) {
-    fd.append(key, value);
-  }
-  return fetch(Config.reportLanding, {
-    body: fd,
-    method: "POST",
-  }).then(async response => {
-    if (!response.ok) {
-      throw new DOMException(
-        `Got ${response.status} status from server: ${response.statusText}`,
-        "NetworkError");
-    }
-  }).catch(error => {
-    Config.maybeSendTelemetry({reportSendError: error.message});
-  });
-}
-
 const portToPageAction = (function() {
   let port;
 
   browser.runtime.onConnect.addListener(_port => {
+    // When the page action popup is shown.
     port = _port;
     port.onMessage.addListener(onMessageFromPageAction);
     port.onDisconnect.addListener(function() {
+      // When the page action popup is hidden.
       port = undefined;
+
+      // Inform whichever tab we were actually prompting on/for.
+      if (gCurrentlyPromptingTab) {
+        TabState.get(gCurrentlyPromptingTab.id).then(tabState => {
+          tabState.onPageActionHidden();
+        });
+      }
+
+      // Update the page action icon for whichever tab we're on now,
+      // or deactivate ourselves if the user clicked "never show again".
       TabState.get().then(tabState => {
-        // When the popup is hidden.
-        updatePageActionIcon(tabState.tabId);
-        if (tabState.isShowingThankYouPage()) {
-          tabState.reset();
-          gCurrentlyPromptingTab = undefined;
-        }
         if (Config.neverShowAgain) {
           deactivate();
+        } else {
+          updatePageActionIcon(tabState.tabId);
         }
       });
     });
 
     TabState.get().then(tabState => {
-      const tabId = tabState.tabId;
-      gCurrentlyPromptingTab = {id: tabId, url: tabState.url};
-      updatePageActionIcon(tabId);
-      tabState.maybeUpdatePageAction();
+      tabState.onPageActionShown();
     });
   });
 
@@ -581,6 +533,8 @@ const TabState = (function() {
 
     reset() {
       this._slide = "initialPrompt";
+      this._blipz_session_id = Date.now().toString();
+      this.takenPageActionExit = undefined;
       this.updateReport();
     }
 
@@ -608,6 +562,10 @@ const TabState = (function() {
 
     get screenshot() {
       return this._report.screenshot;
+    }
+
+    get userPrompted() {
+      return this._report.userPrompted;
     }
 
     updateReport(updates) {
@@ -644,6 +602,7 @@ const TabState = (function() {
     }
 
     async markAsVerified() {
+      this.takenPageActionExit = "done";
       gCurrentlyPromptingTab = undefined;
       await updatePageActionIcon(this._tabId);
     }
@@ -652,15 +611,108 @@ const TabState = (function() {
       return ["thankYou", "thankYouFeedback"].includes(this._slide);
     }
 
+    onPageActionShown() {
+      // Send telemetry on whether the user was actively prompted or
+      // not the first time the popup is brought up, but also when
+      // they call up the popup themselves (but not if they're
+      // coming back after clicking an internal link/screenshot).
+      if (!this.takenPageActionExit) {
+        const selfPrompted = this.userPrompted ? "no" : "yes";
+        this.maybeSendTelemetry({selfPrompted});
+      }
+
+      // Clear which link/screenshot the user clicked on which closed
+      // the popup last time (unless we're done, at which point we don't
+      // care if the user dismisses the popup anymore).
+      if (this.takenPageActionExit !== "done") {
+        this.takenPageActionExit = undefined;
+      }
+
+      // Start a new session if opening on a tab already on a thank-you page.
+      if (this.isShowingThankYouPage()) {
+        this.reset();
+        gCurrentlyPromptingTab = undefined;
+      }
+
+      gCurrentlyPromptingTab = {id: this._tabId, url: this._url};
+      updatePageActionIcon(this._tabId);
+      this.maybeUpdatePageAction();
+    }
+
+    onPageActionHidden() {
+      // If the page action closes and it is not because the user has
+      // just clicked an internal link/screenshot (both of which will
+      // open a tab and close the page action), then we presume the
+      // user dismissed the popup themselves.
+      if (!this.takenPageActionExit) {
+        this.maybeSendTelemetry({userDismissed: "yes"});
+      }
+    }
+
+    _backgroundSendReport(data) {
+      data.type = browser.i18n.getMessage(`issueLabel${data.type}`);
+
+      const body = ["url", "type", "appVersion", "channel", "platform", "buildID",
+                    "experimentBranch", "description"].map(function(name) {
+          const label = browser.i18n.getMessage(`detailLabel_${name}`);
+          const value = data[name] || "";
+          return `**${label}** ${value}`;
+        }).join("\n");
+
+      const domain = Config.findDomainMatch(new URL(data.url).host);
+
+      const report = {
+        title: `${domain} - ${data.type}`,
+        body,
+        labels: [`variant-${data.experimentBranch}`],
+      };
+
+      if (data.userPrompted) {
+        report.labels.push("user-prompted");
+      }
+
+      if (data.screenshot) {
+        report.screenshot = data.screenshot;
+      }
+
+      if (Config.testingMode) {
+        console.info("Would submit this report: ", report);
+        return Promise.resolve();
+      }
+
+      const fd = new FormData();
+      for (const [key, value] of Object.entries(report)) {
+        fd.append(key, value);
+      }
+      return fetch(Config.reportLanding, {
+        body: fd,
+        method: "POST",
+      }).then(async response => {
+        if (!response.ok) {
+          throw new DOMException(
+            `Got ${response.status} status from server: ${response.statusText}`,
+            "NetworkError");
+        }
+      }).catch(error => {
+        this.maybeSendTelemetry({reportSendError: error.message});
+      });
+    }
+
+    maybeSendTelemetry(message) {
+      browser.study.sendTelemetry(Object.assign({blipz_session_id: this._blipz_session_id}, message));
+    }
+
     async submitReport() {
       if (this._reportSubmitPromise) {
         return this._reportSubmitPromise;
       }
 
+      this.maybeSendTelemetry({shareFeedBack: "userSubmitted"});
+
       this._reportSubmitPromise = new Promise(async (resolve, reject) => {
         const report = this._report;
         this.updateReport();
-        return backgroundSendReport(report).then(() => {
+        return this._backgroundSendReport(report).then(() => {
           delete this._reportSubmitPromise;
           resolve();
         }).catch(error => {
@@ -831,26 +883,39 @@ async function promptUser(tabId, url) {
 }
 
 async function onMessageFromPageAction(message) {
-  const { tabId, command } = message;
+  const { tabId, command, exit } = message;
+
+  const tabState = await TabState.get(tabId);
 
   if ("neverShowAgain" in message) {
     const neverShowAgain = message.neverShowAgain;
     Config.neverShowAgain = neverShowAgain;
     if (neverShowAgain) {
+      tabState.maybeSendTelemetry({clickedDontShowAgain: "yes"});
       return undefined;
     }
     delete message.neverShowAgain;
   }
 
-  const tabState = await TabState.get(tabId);
-
   delete message.tabId;
   delete message.command;
+  delete message.exit;
   if (Object.keys(message).length) {
     tabState.updateReport(message);
   }
 
   switch (command) {
+    case "leavingPageAction": {
+      if (exit) {
+        tabState.takenPageActionExit = exit;
+        if (exit === "why") {
+          tabState.maybeSendTelemetry({clickedWhySeeingThis: "yes"});
+        } else if (exit === "learnMore") {
+          tabState.maybeSendTelemetry({clickedLearnMore: "yes"});
+        }
+      }
+      break;
+    }
     case "removeScreenshot": {
       tabState.updateReport({screenshot: undefined});
       tabState.maybeUpdatePageAction(["screenshot"]);
@@ -947,7 +1012,7 @@ async function handleButtonClick(command, tabState) {
   switch (tabState.slide) {
     case "initialPrompt": {
       const siteWorks = command === "yes";
-      Config.maybeSendTelemetry({satisfiedSitePrompt: yesOrNo(siteWorks)});
+      tabState.maybeSendTelemetry({satisfiedSitePrompt: yesOrNo(siteWorks)});
       if (siteWorks) {
         tabState.slide = "thankYou";
         tabState.markAsVerified();
@@ -968,6 +1033,7 @@ async function handleButtonClick(command, tabState) {
       } else if (command === "cancel") {
         closePageAction();
         tabState.reset();
+        tabState.maybeSendTelemetry({shareFeedBack: "userCancelled"});
       }
       tabState.markAsVerified();
       break;
@@ -983,6 +1049,7 @@ async function handleButtonClick(command, tabState) {
         closePageAction();
         tabState.reset();
         tabState.markAsVerified();
+        tabState.maybeSendTelemetry({shareFeedBack: "userCancelled"});
       }
       break;
     }

--- a/webextension/popup.html
+++ b/webextension/popup.html
@@ -13,7 +13,7 @@
     <section id="initialPrompt">
       <h1></h1>
       <p></p>
-      <a href="https://webcompat.mozilla.community/better"></a>
+      <a data-exit="why" href="https://webcompat.mozilla.community/better"></a>
       <label>
         <input type="checkbox" name="neverShowAgain" />
       </label>
@@ -27,7 +27,7 @@
     <section id="thankYouFeedback">
       <h1></h1>
       <p></p>
-      <a href="https://webcompat.mozilla.community/thanks"></a>
+      <a data-exit="learnMore" href="https://webcompat.mozilla.community/thanks"></a>
       <button data-action="ok"></button>
     </section>
     <section id="feedbackForm">
@@ -47,7 +47,7 @@
         <button class="takeScreenshot"></button>
         <div class="screenshot">
           <p></p>
-          <img src="screenshot.jpg" alt="" />
+          <img data-exit="screenshot" src="screenshot.jpg" alt="" />
           <button></button>
         </div>
         <textarea name="description" rows="1"></textarea>
@@ -72,7 +72,7 @@
       </table>
       <div class="screenshot">
         <p></p>
-        <img src="screenshot.jpg" alt="" />
+        <img data-exit="screenshot" src="screenshot.jpg" alt="" />
       </div>
       <p></p>
       <button data-action="cancel"></button>

--- a/webextension/popup.js
+++ b/webextension/popup.js
@@ -32,6 +32,7 @@ const portToBGScript = (function() {
 
   async function send(message) {
     if (port) {
+      message.tabId = gState.tabId;
       return port.postMessage(message);
     }
     console.trace();
@@ -173,6 +174,11 @@ function showScreenshot(dataUrl) {
 function handleClick(e) {
   if (e.which !== 1) {
     return;
+  }
+
+  const exit = e.target.getAttribute("data-exit");
+  if (exit) {
+    portToBGScript.send({command: "leavingPageAction", exit});
   }
 
   if (e.target.matches(".screenshot > button")) {


### PR DESCRIPTION
@tdsmith, I can't seem to add you as a reviewer, but I suspect your review will be necessary here.

Note that with this PR, during each individual Blipz session, every time the user seems to dismiss the popup we'll get a `userDismissed=yes` ping, and then when they call the popup back up we'll get a `selfPrompted=yes` ping.

However, if the user clicks on an internal link (learn more, etc) or screenshot and then comes back to the tab, I will not send these extra pings (as I feel they didn't really dismiss the wizard themselves, they were just taken to another tab temporarily).

However however, those extra pings will be sent *in addition to* a potential initial `selfPrompted=no` ping if they were actively prompted, as well as other pings for whether they ultimately cancel/submit for that session.

If we want to change this so that only *one* `userDismissed=yes/no` ping is ever sent per-session (and likewise only *one* `selfPrompted=yes/no`), I should be able to work that out as well.

Code-wise the PR does a couple of things that might be worth pointing out for easier review:
- moves `maybeSendTelemetry` and `backgroundSendReport` into the `TabState` class so that it can automatically add the `blipz_session_id` to outgoing telemetry. `backgroundSendReport` doesn't actually change aside from its telemetry call.
- corrects a couple of minor flaws;
  - actually set the tabId on the messages the page action sends to the background page
  - make the choice whether to restart the wizard (if the user was last on a thank-you page) to when the popup is called up, not when it's dismissed.