### PR TITLE
Address extra feedback from PR #65

### DIFF
--- a/webextension/background.js
+++ b/webextension/background.js
@@ -123,7 +123,7 @@ const Config = (function() {
         },
         endings: {
           "user-disable": {
-            baseUrls: ["https://www.surveygizmo.com/s3/4388018/Blipz-shield-survey"],
+            baseUrls: ["https://www.surveygizmo.com/s3/4388018/Blipz-shield-survey?reason=disabled"],
           },
           expired: {
             baseUrls: ["https://www.surveygizmo.com/s3/4388018/Blipz-shield-survey"],

--- a/webextension/background.js
+++ b/webextension/background.js
@@ -123,14 +123,10 @@ const Config = (function() {
         },
         endings: {
           "user-disable": {
-            baseUrl: null,
+            baseUrls: ["https://www.surveygizmo.com/s3/4388018/Blipz-shield-survey"],
           },
           expired: {
-            baseUrl: null,
-          },
-          dataPermissionsRevoked: {
-            baseUrl: null,
-            study_state: "ended-neutral",
+            baseUrls: ["https://www.surveygizmo.com/s3/4388018/Blipz-shield-survey"],
           },
         },
         logLevel: this._testingMode ? 30 : 0,


### PR DESCRIPTION
Drops the `enabled` `about:config` pref, removes now-obsolete code to manage the neverShowAgain stuff, and just uninstalls the addon at the appropriate time. Also corrects the Shield study setup variables for our surveys.