### PR TITLE
Ensure exit survey is shown on expiry, that telemetry pings are sent, and fix auto-prompting when returning to feedback details (#106, #108, #110)

### DIFF
--- a/webextension/background.js
+++ b/webextension/background.js
@@ -1140,6 +1140,7 @@ async function handleButtonClick(command, tabState) {
       if (command === "submit") {
         tabState.submitReport();
         tabState.slide = "thankYouFeedback";
+        tabState.markAsVerified();
       } else if (command === "showFeedbackDetails") {
         tabState.slide = "feedbackDetails";
         tabState.maybeUpdatePageAction(["type", "description"]);
@@ -1148,9 +1149,9 @@ async function handleButtonClick(command, tabState) {
       } else if (command === "cancel") {
         closePageAction();
         tabState.reset();
+        tabState.markAsVerified();
         tabState.maybeSendTelemetry({shareFeedBack: "userCancelled"});
       }
-      tabState.markAsVerified();
       break;
     }
     case "feedbackDetails": {

--- a/webextension/background.js
+++ b/webextension/background.js
@@ -167,7 +167,7 @@ const Config = (function() {
         allowEnroll: true,
         studyType: "shield",
         telemetry: {
-          send: !this._testingMode,
+          send: true,
           removeTestingFlag: !this._testingMode,
         },
         endings: {

--- a/webextension/manifest.json
+++ b/webextension/manifest.json
@@ -53,6 +53,7 @@
     "128": "icons/broken_page.svg"
   },
   "permissions": [
+    "alarms",
     "storage",
     "tabs",
     "webNavigation",


### PR DESCRIPTION
As written in the bug, I bypass the shield mechanism for expiry for now so it actually works and surveys will be offered. To do this I'm adding our own pref just in case, which the addon will clear on its own. By the time we're past the experimental stage, Shield will hopefully have figured this stuff out so we can simplify the code, but it doesn't seem worth blocking on for now.

Edit: I've also added the fix for #110, since it's simple.