### PR TITLE
Submit the correct report information for slow site feedback. #222

### DIFF
--- a/webextension/_locales/en_US/messages.json
+++ b/webextension/_locales/en_US/messages.json
@@ -65,6 +65,9 @@
   "issueLabelOther": {
     "message": "Something else"
   },
+  "issueLabelSiteIsSlow": {
+    "message": "Site is slow"
+  },
   "labelNeverShowAgain": {
     "message": "Don't show this again"
   },

--- a/webextension/background.js
+++ b/webextension/background.js
@@ -809,7 +809,7 @@ const TabState = (function() {
         labels: [`variant-${data.experimentBranch}`, `blipz-${BlipzVersion}`],
       };
 
-      if (data.description === "Site is slow") {
+      if (data.type === "siteIsSlow") {
         report.labels.push("slow-site");
       }
 
@@ -1365,7 +1365,11 @@ SlideButtonClickHandlers.performancePrompt = (command, tabState) => {
 
 SlideButtonClickHandlers.performanceFeedback = (command, tabState) => {
   if (command === "submitPerformanceFeedback") {
-    tabState.updateReport({description: "Site is slow"});
+    // Clear the report and submit only the "it's slow" feedback. Otherwise
+    // we might have details from "something else" if the user clicked back.
+    const description = tabState._report.performanceDescription;
+    tabState.updateReport();
+    tabState.updateReport({type: "siteIsSlow", description});
     tabState.submitReport();
     tabState.slide = "thankYouFeedback";
     tabState.markAsVerified();


### PR DESCRIPTION
This is actually what we want here; it should clear the bits of the report carried over from the other "something else" feedback, since the user didn't want to submit that. It should then just submit a "slow" type, "slow" label, and the description the user typed in the expected box.